### PR TITLE
Don't use DefaultClient, as it shares state implicitly and can cause

### DIFF
--- a/api.go
+++ b/api.go
@@ -43,7 +43,7 @@ func NewClient(email string, token string) (*Client, error) {
 		Token: token,
 		Email: email,
 		URL:   "https://www.cloudflare.com/api_json.html",
-		Http:  http.DefaultClient,
+		Http:  &http.Client{},
 	}
 	return &client, nil
 }


### PR DESCRIPTION
hard-to-track-down errors.
