### PR TITLE
Update record.go

### DIFF
--- a/record.go
+++ b/record.go
@@ -232,6 +232,8 @@ func (c *Client) UpdateRecord(domain string, id string, opts *UpdateRecord) erro
 
 	if opts.Ttl != "" {
 		params["ttl"] = opts.Ttl
+	} else {
+		params["ttl"] = "1"
 	}
 
 	req, err := c.NewRequest(params, "POST", "rec_edit")


### PR DESCRIPTION
Iif not set ttl, it creates. But if you try to update record, error raise, because ttl must be "1"
